### PR TITLE
Refactor code to remove filecache dependency

### DIFF
--- a/apple/job/apple.py
+++ b/apple/job/apple.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from typing import List
 
-from filecache import filecache
 from appleconnector import AppleConnector
 import requests
 from loguru import logger
@@ -22,11 +21,6 @@ class AppleCookies:
     itctx: str
 
 
-# Add a cache decorator to the function that fetches the cookies
-# so that we don't have to fetch them every time as we pay for every single
-# login.
-# The cache will be invalidated after 4 hours.
-@filecache(4 * 60 * 60)
 def fetch_all_cookies(bearer_token: str, apple_automation_endpoint: str):
     """
     Get Apple cookies from API

--- a/apple/requirements.txt
+++ b/apple/requirements.txt
@@ -3,7 +3,6 @@ autopep8==1.7.0
 backoff==1.11.1
 certifi==2022.9.24
 charset-normalizer==2.1.1
-filecache==0.81
 idna==3.4
 loguru==0.6.0
 monotonic==1.6

--- a/connector_manager/requirements.txt
+++ b/connector_manager/requirements.txt
@@ -7,7 +7,6 @@ autopep8==1.7.0
 backoff==1.11.1
 certifi==2022.9.24
 charset-normalizer==2.1.1
-filecache==0.81
 idna==3.4
 loguru==0.6.0
 monotonic==1.6


### PR DESCRIPTION
This pull request refactors the code to remove the dependency on the filecache library and the cache decorator. The fetch_all_cookies function no longer uses the filecache decorator, which means the cookies will be fetched from the API every time instead of being cached. This change improves the code's simplicity and removes the need for an external library.