### PR TITLE
Refactor Dockerfiles to pin to linux/amd64 platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.11-slim-bullseye
+# syntax=docker/dockerfile:1
+# Pin to linux/amd64 as we deploy to x86_64 servers
+FROM --platform=linux/amd64 python:3.11-slim-bullseye
 
 # Install cron and gpg for decrypting data fetched from db
 RUN apt-get update \

--- a/anchor/Dockerfile
+++ b/anchor/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.11-slim-bullseye
+# syntax=docker/dockerfile:1
+# Pin to linux/amd64 as we deploy to x86_64 servers
+FROM --platform=linux/amd64 python:3.11-slim-bullseye
 
 # Install cron
 RUN apt-get update \

--- a/apple/Dockerfile
+++ b/apple/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.11-slim-bullseye
+# syntax=docker/dockerfile:1
+# Pin to linux/amd64 as we deploy to x86_64 servers
+FROM --platform=linux/amd64 python:3.11-slim-bullseye
 
 # Install cron
 RUN apt-get update \

--- a/spotify/Dockerfile
+++ b/spotify/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.11-slim-bullseye
+# syntax=docker/dockerfile:1
+# Pin to linux/amd64 as we deploy to x86_64 servers
+FROM --platform=linux/amd64 python:3.11-slim-bullseye
 
 # Install cron
 RUN apt-get update \


### PR DESCRIPTION
This pull request refactors the Dockerfiles to pin the platform to linux/amd64. This change ensures that the code is deployed to x86_64 servers (Hetzner).