### PR TITLE
Add support for Spotify impressions

### DIFF
--- a/spotify/job/__main__.py
+++ b/spotify/job/__main__.py
@@ -186,6 +186,14 @@ try:
             start_date=date_range.start,
             end_date=date_range.end,
         ),
+        FetchParams(
+            openpodcast_endpoint="impressions_funnel",
+            spotify_call=get_request_lambda(
+                spotify.impressions, "funnel", todayDate - dt.timedelta(days=14), todayDate
+            ),
+            start_date=date_range.start,
+            end_date=date_range.end,
+        ),
     ] + [
         # Fetch aggregate data for the podcast for each individual day
         # Otherwise we get all data merged into one

--- a/spotify/job/__main__.py
+++ b/spotify/job/__main__.py
@@ -16,6 +16,10 @@ from loguru import logger
 from spotifyconnector import SpotifyConnector
 from spotifyconnector.connector import CredentialsExpired
 
+# The Spotify API imposes exactly 30 days of data for "total" and "faceted" impressions
+# (The diff is 29 because both start and end dates are inclusive)
+IMPRESSIONS_DAYS_DIFF = 29
+
 try:
     print("Initializing environment")
 
@@ -116,7 +120,13 @@ try:
         return lambda: f(*args, **kwargs)
 
 
-    todayDate = dt.datetime.now()
+    # Use a clean date for "today" at midnight. This avoids issues with the
+    # impresions endpoint which requires exact date ranges.
+    # (For "total" and "faceted" impressions, start and end must be exactly IMPRESSIONS_DAYS_DIFF 
+    # days apart.
+    # See: https://github.com/openpodcast/spotify-connector/blob/2d3f9722662c06e8f9ddf7816c1ee81906d45655/spotifyconnector/connector.py#L460-L479)
+    # It does not affect any other endpoints
+    todayDate = dt.datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
     yesterdayDate = todayDate - dt.timedelta(days=1)
     oldestDate = dt.datetime(2015, 5, 1)
 
@@ -154,7 +164,17 @@ try:
         ),
         FetchParams(
             openpodcast_endpoint="impressions_total",
-            spotify_call=get_request_lambda(spotify.impressions, "total", date_range.start),
+            # Total impressions are only available for the last 30 days
+            spotify_call=get_request_lambda(spotify.impressions, "total", todayDate - dt.timedelta(days=IMPRESSIONS_DAYS_DIFF), todayDate),
+            start_date=date_range.start,
+            end_date=date_range.end,
+        ),
+        FetchParams(
+            openpodcast_endpoint="impressions_faceted",
+            spotify_call=get_request_lambda(
+                # Faceted impressions are only available for the last 30 days
+                spotify.impressions, "faceted", todayDate - dt.timedelta(days=IMPRESSIONS_DAYS_DIFF), todayDate 
+            ),
             start_date=date_range.start,
             end_date=date_range.end,
         ),
@@ -162,14 +182,6 @@ try:
             openpodcast_endpoint="impressions_daily",
             spotify_call=get_request_lambda(
                 spotify.impressions, "daily", todayDate - dt.timedelta(days=14), todayDate
-            ),
-            start_date=date_range.start,
-            end_date=date_range.end,
-        ),
-        FetchParams(
-            openpodcast_endpoint="impressions_faceted",
-            spotify_call=get_request_lambda(
-                spotify.impressions, "faceted", todayDate - dt.timedelta(days=14), todayDate
             ),
             start_date=date_range.start,
             end_date=date_range.end,

--- a/spotify/job/__main__.py
+++ b/spotify/job/__main__.py
@@ -152,6 +152,28 @@ try:
             start_date=date_range.start,
             end_date=date_range.end,
         ),
+        FetchParams(
+            openpodcast_endpoint="impressions_total",
+            spotify_call=get_request_lambda(spotify.impressions, "total", date_range.start),
+            start_date=date_range.start,
+            end_date=date_range.end,
+        ),
+        FetchParams(
+            openpodcast_endpoint="impressions_daily",
+            spotify_call=get_request_lambda(
+                spotify.impressions, "daily", todayDate - dt.timedelta(days=14), todayDate
+            ),
+            start_date=date_range.start,
+            end_date=date_range.end,
+        ),
+        FetchParams(
+            openpodcast_endpoint="impressions_faceted",
+            spotify_call=get_request_lambda(
+                spotify.impressions, "faceted", todayDate - dt.timedelta(days=14), todayDate
+            ),
+            start_date=date_range.start,
+            end_date=date_range.end,
+        ),
     ] + [
         # Fetch aggregate data for the podcast for each individual day
         # Otherwise we get all data merged into one


### PR DESCRIPTION
This adds the new calls to Spotify impressions to our pipeline.

Closes: https://github.com/openpodcast/pipelines/issues/68

See also:

- Roadmap: https://github.com/openpodcast/roadmap/issues/107
- API implementation: https://github.com/openpodcast/api/pull/197
- Original Spotify connector PR for impressions: https://github.com/openpodcast/spotify-connector/pull/10
- Original Spotify connector issue: https://github.com/openpodcast/spotify-connector/issues/8