### PR TITLE
Podigee total numbers

### DIFF
--- a/connector_manager/manager/podigee_connector.py
+++ b/connector_manager/manager/podigee_connector.py
@@ -83,7 +83,7 @@ def handle_podigee_refresh(db_connection, account_id, source_name, source_access
     
     # Get refresh token from source_access_keys
     refresh_token = source_access_keys.get("PODIGEE_REFRESH_TOKEN")
-    logger.debug(f"Using refresh token: {refresh_token}")    
+    logger.debug(f"Using refresh token: {refresh_token[:10]}... for {pod_name}")
     if not client_id or not client_secret or not refresh_token:
         logger.error(f"Missing required OAuth credentials for Podigee: {pod_name}")
         return None

--- a/podigee/.env.sample
+++ b/podigee/.env.sample
@@ -5,4 +5,4 @@ PODIGEE_USERNAME="username"
 PODIGEE_PASSWORD="password"
 PODCAST_ID=12345
 
-OPENPODCAST_ACCESS_TOKEN=your_access_token_here
+PODIGEE_ACCESS_TOKEN=your_access_token_here


### PR DESCRIPTION
Implement an endpoint to retrieve total numbers of podcasts and episodes from Podigee, including unique listeners, unique subscribers, and total downloads. Enhance debug logging for refresh token usage to improve security by truncating token display. Fixes #100.

see also openpodcast/api#198